### PR TITLE
Enable comments min spaces checks

### DIFF
--- a/.github/config/lintconf.yaml
+++ b/.github/config/lintconf.yaml
@@ -18,8 +18,8 @@ rules:
     min-spaces-after: 1
     max-spaces-after: 1
   comments:
-    require-starting-space: false
-    min-spaces-from-content: 2
+    require-starting-space: true
+    min-spaces-from-content: 1
   document-end: disable
   document-start: disable           # No --- to start a file
   empty-lines:


### PR DESCRIPTION
Now linter check spaces in values.yaml. Commentaries should be started from 1 space